### PR TITLE
Add carousel item display mode

### DIFF
--- a/cambridge_news.features.field_instance.inc
+++ b/cambridge_news.features.field_instance.inc
@@ -95,9 +95,13 @@ function cambridge_news_field_default_field_instances() {
     'description' => '',
     'display' => array(
       'carousel_item' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
+        'label' => 'hidden',
+        'module' => 'image',
+        'settings' => array(
+          'image_link' => 'content',
+          'image_style' => 'carousel',
+        ),
+        'type' => 'image',
         'weight' => 0,
       ),
       'default' => array(


### PR DESCRIPTION
In the event that a news article appears in the carousel it currently isn't set to display anything, this adds in the image.
