### PR TITLE
Add absolute_url setting to field_related_links

### DIFF
--- a/cambridge_news.features.field_instance.inc
+++ b/cambridge_news.features.field_instance.inc
@@ -297,6 +297,7 @@ function cambridge_news_field_default_field_instances() {
     'label' => 'Related links',
     'required' => 0,
     'settings' => array(
+      'absolute_url' => 1,
       'attributes' => array(
         'class' => '',
         'configurable_title' => 0,


### PR DESCRIPTION
http://cgit.drupalcode.org/link/commit/?id=85ab462 added a `absolute_url` setting to link fields, so the feature currently appears as overriden.
